### PR TITLE
Config null check

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -29,7 +29,7 @@ exports.load = function(fileName, currentEnv) {
       //Check config entry's for ENV objects
       //which will tell us to grab configuration from the environment
       for (var configEntry in config[env]) {
-        if (config[env][configEntry].ENV != null){
+        if (config[env][configEntry] && config[env][configEntry].ENV != null){
           config[env][configEntry] =  process.env[config[env][configEntry].ENV];
         }
       }

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -106,5 +106,22 @@ vows.describe('config').addBatch({
       assert.equal(current.settings.database, 'dbname');
     }
   }
-}).export(module);
+}).addBatch({
+  'loading a config with null values': {
+    topic: function() {
+        var configPath = path.join(__dirname, 'database_with_null_values.json');
+        config.load = _configLoad;
+        config.loadUrl = _configLoadUrl;
+        try {
+            config.load(configPath, 'dev');
+        }catch(e) {
+            return e;
+        }
+        return null;
+    },
 
+    'should something': function(err) {
+        assert.isNull(err);
+    }
+  }
+}).export(module);

--- a/test/database_with_null_values.json
+++ b/test/database_with_null_values.json
@@ -1,0 +1,16 @@
+{
+    "dev": {
+        "driver": null,
+        "filename": ":memory:"
+    },
+
+    "test": {
+        "driver": null,
+        "filename": ":memory:"
+    },
+
+    "prod": {
+        "driver": null,
+        "filename": "prod.db"
+    }
+}


### PR DESCRIPTION
When config values are null or undefined (which I realize will cause connection issues), the `ENV` property check throws an error.  Adding a truthy check for the property to harden it slightly and avoid an error from being thrown from somewhere that might not be obvious for users.