### PR TITLE
[Bugfix] never delete index together with foreign key

### DIFF
--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -252,12 +252,7 @@ var MysqlDriver = Base.extend({
 
   removeForeignKey: function(tableName, keyName, callback) {
     var sql = util.format('ALTER TABLE `%s` DROP FOREIGN KEY `%s`', tableName, keyName);
-    this.runSql(sql, function () {
-      sql = util.format('ALTER TABLE `%s` DROP INDEX `%s`', tableName, keyName);
-      this.runSql(sql, function () {
-        callback();
-      });
-    }.bind(this));
+    this.runSql(sql, callback());
   },
 
   runSql: function() {

--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -250,7 +250,25 @@ var MysqlDriver = Base.extend({
     this.runSql(sql, callback);
   },
 
-  removeForeignKey: function(tableName, keyName, callback) {
+  removeForeignKey: function(tableName, keyName, options, callback) {
+    var sql = util.format('ALTER TABLE `%s` DROP FOREIGN KEY `%s`', tableName, keyName);
+    this.runSql(sql, function () {
+
+      if( typeof(options) === 'function' ) {
+
+          options();
+      }
+      else if(options.dropIndex === true) {
+
+        sql = util.format('ALTER TABLE `%s` DROP INDEX `%s`', tableName, keyName);
+        this.runSql(sql, function () {
+          callback();
+        });
+      }
+      else
+        callback();
+
+    }.bind(this));
     var sql = util.format('ALTER TABLE `%s` DROP FOREIGN KEY `%s`', tableName, keyName);
     this.runSql(sql, callback());
   },

--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -269,8 +269,6 @@ var MysqlDriver = Base.extend({
         callback();
 
     }.bind(this));
-    var sql = util.format('ALTER TABLE `%s` DROP FOREIGN KEY `%s`', tableName, keyName);
-    this.runSql(sql, callback());
   },
 
   runSql: function() {


### PR DESCRIPTION
the operation of deleting a foreign key should be granular and not deleting any indexes automatically. Otherwise this leads to unexpected behavior and breaks the migrations.

An example, you have created the key manually before and later decided to put a foreign key. No a while later again you delete the foreign key, but you still need the index, which is lost now. Also the down migration you created for this key is now broken.