### PR TITLE
Fixed the error Cannot find module 'mongodb'

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "moment": "~2.9.0",
     "pkginfo": "~0.3.0",
     "parse-database-url": "~0.2.2",
-    "dotenv": "~0.5.1"
+    "dotenv": "~0.5.1",
+    "mongodb": "^1.4.30"
   },
   "devDependencies": {
     "code": "^1.3.0",
     "db-meta": "~0.4.1",
     "lab": "^5.2.1",
-    "mongodb": "^1.4.30",
     "mysql": "~2.5.4",
     "pg": "~4.2.0",
     "rimraf": "~2.2.8",


### PR DESCRIPTION
I was getting the error below when trying to use node-db-migrate from your latest commit:

```sh
$ db-migrate up
[ERROR] Error: Cannot find module 'mongodb'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/db-migrate/lib/driver/mongodb.js:3:19)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```