### PR TITLE
Allow database URL to be specified via an environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,12 @@ You can also specify environment variables in your config file by using a specia
 In this case, db-migrate will search your environment for variables
 called `PRODUCTION_USERNAME` and `PRODUCTION_PASSWORD`, and use those values for the corresponding configuration entry.
 
-Note that if the settings for an environment are represented by a single string that string will be parsed as a database URL.
+Note that if the settings for an environment are represented by a single string that string will be parsed as a database URL.  You can also provide a database URL through environmental variable like this:
+```javascript
+{
+  "prod": {"ENV": "PRODUCTION_URL"}
+}
+```
 
 You can pass the -e or --env option to db-migrate to select the environment you want to run migrations against. The --config option can be used to specify the path to your database.json file if it's not in the current working directory.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,7 +23,9 @@ exports.load = function(fileName, currentEnv) {
   }
 
   for (var env in config) {
-    if (typeof(config[env]) == "string") {
+    if (config[env].ENV != null) {
+      exports[env] = parseDatabaseUrl(process.env[config[env].ENV]);
+    } else if (typeof(config[env]) == "string") {
       exports[env] = parseDatabaseUrl(config[env]);
     } else {
       //Check config entry's for ENV objects

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -74,6 +74,27 @@ vows.describe('config').addBatch({
 }
 
 }).addBatch({
+  'loading from a file with ENV URL': {
+    topic: function() {
+      process.env['DB_MIGRATE_TEST_VAR'] = 'postgres://uname:pw@server.com/dbname';
+      var configPath = path.join(__dirname, 'database_with_env_url.json');
+      config.load = _configLoad;
+      config.loadUrl = _configLoadUrl;
+      config.load(configPath, 'prod');
+      return config;
+    },
+
+    'should load a value from the environments': function (config) {
+      var current = config.getCurrent();
+      assert.equal(current.settings.driver, 'postgres');
+      assert.equal(current.settings.user, 'uname');
+      assert.equal(current.settings.password, 'pw');
+      assert.equal(current.settings.host, 'server.com');
+      assert.equal(current.settings.database, 'dbname');
+    },
+}
+
+}).addBatch({
   'loading from an URL': {
     topic: function() {
       var databaseUrl = 'postgres://uname:pw@server.com/dbname';

--- a/test/database_with_env_url.json
+++ b/test/database_with_env_url.json
@@ -1,0 +1,3 @@
+{
+  "prod": {"ENV": "DB_MIGRATE_TEST_VAR"}
+}


### PR DESCRIPTION
Adds the ability for a database URL to be provided via an environmental variable so that the following will work:

```javascript
{
  "prod": {"ENV": "PRODUCTION_URL"}
}
```

Includes update to README and a new test that fails without this change.