### PR TITLE
Add `var` keywords in front of `dbm` declaration in templates.

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -53,7 +53,7 @@ Migration.prototype.defaultCoffeeTemplate = function() {
 
 Migration.prototype.defaultJsTemplate = function() {
   return [
-    "dbm = dbm || require('db-migrate');",
+    "var dbm = dbm || require('db-migrate');",
     "var type = dbm.dataType;",
     "",
     "exports.up = function(db, callback) {",
@@ -74,7 +74,7 @@ Migration.prototype.defaultSqlTemplate = function() {
 
 Migration.prototype.sqlFileLoaderTemplate = function() {
   return [
-    "dbm = dbm || require('db-migrate');",
+    "var dbm = dbm || require('db-migrate');",
     "var type = dbm.dataType;",
     "var fs = require('fs');",
     "var path = require('path');",


### PR DESCRIPTION
fixes #240, adds the missing var statements. 